### PR TITLE
fix error objects: with --use_strict does not use .callee

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -8,33 +8,38 @@ var OAuth2Error = require('./oauth2error');
  *
  * @api public
  */
-function AuthorizationError(message, code, uri, status) {
-  if (!status) {
-    switch (code) {
-      case 'invalid_request':
-        status = 400;break;
-      case 'unauthorized_client':
-        status = 403;break;
-      case 'access_denied':
-        status = 403;break;
-      case 'unsupported_response_type':
-        status = 501;break;
-      case 'invalid_scope':
-        status = 400;break;
-      case 'temporarily_unavailable':
-        status = 503;break;
+class AuthorizationError extends OAuth2Error {
+  constructor(message, code, uri, status) {
+    super(message, code, uri, status);
+
+    this.name = 'AuthorizationError';
+
+    if (!status) {
+      switch (code) {
+        case 'invalid_request':
+          status = 400;
+          break;
+        case 'unauthorized_client':
+          status = 403;
+          break;
+        case 'access_denied':
+          status = 403;
+          break;
+        case 'unsupported_response_type':
+          status = 501;
+          break;
+        case 'invalid_scope':
+          status = 400;
+          break;
+        case 'temporarily_unavailable':
+          status = 503;
+          break;
+      }
     }
+
+    Error.captureStackTrace(this, this.constructor);
   }
-
-  OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'AuthorizationError';
 }
-
-/**
- * Inherit from `OAuth2Error`.
- */
-AuthorizationError.prototype.__proto__ = OAuth2Error.prototype;
 
 /**
  * Expose `AuthorizationError`.

--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -17,22 +17,22 @@ class AuthorizationError extends OAuth2Error {
     if (!status) {
       switch (code) {
         case 'invalid_request':
-          status = 400;
+          this.status = 400;
           break;
         case 'unauthorized_client':
-          status = 403;
+          this.status = 403;
           break;
         case 'access_denied':
-          status = 403;
+          this.status = 403;
           break;
         case 'unsupported_response_type':
-          status = 501;
+          this.status = 501;
           break;
         case 'invalid_scope':
-          status = 400;
+          this.status = 400;
           break;
         case 'temporarily_unavailable':
-          status = 503;
+          this.status = 503;
           break;
       }
     }

--- a/lib/errors/badrequesterror.js
+++ b/lib/errors/badrequesterror.js
@@ -3,18 +3,17 @@
  *
  * @api public
  */
-function BadRequestError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'BadRequestError';
-  this.message = message;
-  this.status = 400;
-}
+class BadRequestError extends Error {
+  constructor(message) {
+    super(message);
 
-/**
- * Inherit from `Error`.
- */
-BadRequestError.prototype.__proto__ = Error.prototype;
+    this.name = 'BadRequestError';
+    this.message = message;
+    this.status = 400;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
 
 /**
  * Expose `BadRequestError`.

--- a/lib/errors/forbiddenerror.js
+++ b/lib/errors/forbiddenerror.js
@@ -3,18 +3,17 @@
  *
  * @api public
  */
-function ForbiddenError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'ForbiddenError';
-  this.message = message;
-  this.status = 403;
-}
+class ForbiddenError extends Error {
+  constructor(message) {
+    super(message);
 
-/**
- * Inherit from `Error`.
- */
-ForbiddenError.prototype.__proto__ = Error.prototype;
+    this.name = 'ForbiddenError';
+    this.message = message;
+    this.status = 403;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
 
 /**
  * Expose `ForbiddenError`.

--- a/lib/errors/oauth2error.js
+++ b/lib/errors/oauth2error.js
@@ -3,18 +3,18 @@
  *
  * @api public
  */
-function OAuth2Error(message, code, uri, status) {
-  Error.call(this);
-  this.message = message;
-  this.code = code || 'server_error';
-  this.uri = uri;
-  this.status = status || 500;
-}
+class OAuth2Error extends Error {
+  constructor(message, code, uri, status) {
+    super(message);
 
-/**
- * Inherit from `Error`.
- */
-OAuth2Error.prototype.__proto__ = Error.prototype;
+    this.message = message;
+    this.code = code || 'server_error';
+    this.uri = uri;
+    this.status = status || 500;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
 
 /**
  * Expose `OAuth2Error`.

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -8,33 +8,38 @@ var OAuth2Error = require('./oauth2error');
  *
  * @api public
  */
-function TokenError(message, code, uri, status) {
-  if (!status) {
-    switch (code) {
-      case 'invalid_request':
-        status = 400;break;
-      case 'invalid_client':
-        status = 401;break;
-      case 'invalid_grant':
-        status = 403;break;
-      case 'unauthorized_client':
-        status = 403;break;
-      case 'unsupported_grant_type':
-        status = 501;break;
-      case 'invalid_scope':
-        status = 400;break;
+class TokenError extends OAuth2Error {
+  constructor(message, code, uri, status) {
+    super(message, code, uri, status);
+
+    this.name = 'TokenError';
+
+    if (!status) {
+      switch (code) {
+        case 'invalid_request':
+          status = 400;
+          break;
+        case 'invalid_client':
+          status = 401;
+          break;
+        case 'invalid_grant':
+          status = 403;
+          break;
+        case 'unauthorized_client':
+          status = 403;
+          break;
+        case 'unsupported_grant_type':
+          status = 501;
+          break;
+        case 'invalid_scope':
+          status = 400;
+          break;
+      }
     }
+
+    Error.captureStackTrace(this, this.constructor);
   }
-
-  OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'TokenError';
 }
-
-/**
- * Inherit from `OAuth2Error`.
- */
-TokenError.prototype.__proto__ = OAuth2Error.prototype;
 
 /**
  * Expose `TokenError`.

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -17,22 +17,22 @@ class TokenError extends OAuth2Error {
     if (!status) {
       switch (code) {
         case 'invalid_request':
-          status = 400;
+          this.status = 400;
           break;
         case 'invalid_client':
-          status = 401;
+          this.status = 401;
           break;
         case 'invalid_grant':
-          status = 403;
+          this.status = 403;
           break;
         case 'unauthorized_client':
-          status = 403;
+          this.status = 403;
           break;
         case 'unsupported_grant_type':
-          status = 501;
+          this.status = 501;
           break;
         case 'invalid_scope':
-          status = 400;
+          this.status = 400;
           break;
       }
     }

--- a/src/errors/authorizationerror.js
+++ b/src/errors/authorizationerror.js
@@ -17,22 +17,22 @@ class AuthorizationError extends OAuth2Error {
     if (!status) {
       switch (code) {
         case 'invalid_request':
-          status = 400;
+          this.status = 400;
           break;
         case 'unauthorized_client':
-          status = 403;
+          this.status = 403;
           break;
         case 'access_denied':
-          status = 403;
+          this.status = 403;
           break;
         case 'unsupported_response_type':
-          status = 501;
+          this.status = 501;
           break;
         case 'invalid_scope':
-          status = 400;
+          this.status = 400;
           break;
         case 'temporarily_unavailable':
-          status = 503;
+          this.status = 503;
           break;
       }
     }

--- a/src/errors/authorizationerror.js
+++ b/src/errors/authorizationerror.js
@@ -8,28 +8,38 @@ var OAuth2Error = require('./oauth2error');
  *
  * @api public
  */
-function AuthorizationError(message, code, uri, status) {
-  if (!status) {
-    switch (code) {
-      case 'invalid_request': status = 400; break;
-      case 'unauthorized_client': status = 403; break;
-      case 'access_denied': status = 403; break;
-      case 'unsupported_response_type': status = 501; break;
-      case 'invalid_scope': status = 400; break;
-      case 'temporarily_unavailable': status = 503; break;
+class AuthorizationError extends OAuth2Error {
+  constructor(message, code, uri, status) {
+    super(message, code, uri, status);
+
+    this.name = 'AuthorizationError';
+
+    if (!status) {
+      switch (code) {
+        case 'invalid_request':
+          status = 400;
+          break;
+        case 'unauthorized_client':
+          status = 403;
+          break;
+        case 'access_denied':
+          status = 403;
+          break;
+        case 'unsupported_response_type':
+          status = 501;
+          break;
+        case 'invalid_scope':
+          status = 400;
+          break;
+        case 'temporarily_unavailable':
+          status = 503;
+          break;
+      }
     }
+
+    Error.captureStackTrace(this, this.constructor);
   }
-  
-  OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'AuthorizationError';
 }
-
-/**
- * Inherit from `OAuth2Error`.
- */
-AuthorizationError.prototype.__proto__ = OAuth2Error.prototype;
-
 
 /**
  * Expose `AuthorizationError`.

--- a/src/errors/badrequesterror.js
+++ b/src/errors/badrequesterror.js
@@ -3,19 +3,17 @@
  *
  * @api public
  */
-function BadRequestError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'BadRequestError';
-  this.message = message;
-  this.status = 400;
+class BadRequestError extends Error {
+  constructor(message) {
+    super(message);
+
+    this.name = 'BadRequestError';
+    this.message = message;
+    this.status = 400;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
 }
-
-/**
- * Inherit from `Error`.
- */
-BadRequestError.prototype.__proto__ = Error.prototype;
-
 
 /**
  * Expose `BadRequestError`.

--- a/src/errors/forbiddenerror.js
+++ b/src/errors/forbiddenerror.js
@@ -3,19 +3,17 @@
  *
  * @api public
  */
-function ForbiddenError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'ForbiddenError';
-  this.message = message;
-  this.status = 403;
+class ForbiddenError extends Error {
+  constructor(message) {
+    super(message);
+
+    this.name = 'ForbiddenError';
+    this.message = message;
+    this.status = 403;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
 }
-
-/**
- * Inherit from `Error`.
- */
-ForbiddenError.prototype.__proto__ = Error.prototype;
-
 
 /**
  * Expose `ForbiddenError`.

--- a/src/errors/oauth2error.js
+++ b/src/errors/oauth2error.js
@@ -3,19 +3,18 @@
  *
  * @api public
  */
-function OAuth2Error(message, code, uri, status) {
-  Error.call(this);
-  this.message = message;
-  this.code = code || 'server_error';
-  this.uri = uri;
-  this.status = status || 500;
+class OAuth2Error extends Error {
+  constructor(message, code, uri, status) {
+    super(message);
+
+    this.message = message;
+    this.code = code || 'server_error';
+    this.uri = uri;
+    this.status = status || 500;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
 }
-
-/**
- * Inherit from `Error`.
- */
-OAuth2Error.prototype.__proto__ = Error.prototype;
-
 
 /**
  * Expose `OAuth2Error`.

--- a/src/errors/tokenerror.js
+++ b/src/errors/tokenerror.js
@@ -8,28 +8,38 @@ var OAuth2Error = require('./oauth2error');
  *
  * @api public
  */
-function TokenError(message, code, uri, status) {
-  if (!status) {
-    switch (code) {
-      case 'invalid_request': status = 400; break;
-      case 'invalid_client': status = 401; break;
-      case 'invalid_grant': status = 403; break;
-      case 'unauthorized_client': status = 403; break;
-      case 'unsupported_grant_type': status = 501; break;
-      case 'invalid_scope': status = 400; break;
+class TokenError extends OAuth2Error {
+  constructor(message, code, uri, status) {
+    super(message, code, uri, status);
+
+    this.name = 'TokenError';
+
+    if (!status) {
+      switch (code) {
+        case 'invalid_request':
+          status = 400;
+          break;
+        case 'invalid_client':
+          status = 401;
+          break;
+        case 'invalid_grant':
+          status = 403;
+          break;
+        case 'unauthorized_client':
+          status = 403;
+          break;
+        case 'unsupported_grant_type':
+          status = 501;
+          break;
+        case 'invalid_scope':
+          status = 400;
+          break;
+      }
     }
+
+    Error.captureStackTrace(this, this.constructor);
   }
-  
-  OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'TokenError';
 }
-
-/**
- * Inherit from `OAuth2Error`.
- */
-TokenError.prototype.__proto__ = OAuth2Error.prototype;
-
 
 /**
  * Expose `TokenError`.

--- a/src/errors/tokenerror.js
+++ b/src/errors/tokenerror.js
@@ -17,22 +17,22 @@ class TokenError extends OAuth2Error {
     if (!status) {
       switch (code) {
         case 'invalid_request':
-          status = 400;
+          this.status = 400;
           break;
         case 'invalid_client':
-          status = 401;
+          this.status = 401;
           break;
         case 'invalid_grant':
-          status = 403;
+          this.status = 403;
           break;
         case 'unauthorized_client':
-          status = 403;
+          this.status = 403;
           break;
         case 'unsupported_grant_type':
-          status = 501;
+          this.status = 501;
           break;
         case 'invalid_scope':
-          status = 400;
+          this.status = 400;
           break;
       }
     }


### PR DESCRIPTION
Code `Error.captureStackTrace(this, arguments.callee);` fails with error `TypeError 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them` 

I have changed errors declaration to avoid this issue